### PR TITLE
feat(room): 取得する期間を変更できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,20 @@ Discord App [`INTERACTIONS ENDPOINT URL`の設定](https://discord.com/developer
 ##### Google v1
 
 ```
-GET /v1/google/sheets/room/today
+GET /v1/google/sheets/room
 ```
 
-Google Sheets から**今日の教室情報**を取得する。
+Google Sheets から教室情報を取得する。
+
+| クエリパラメータ | 値                | 必須 |
+| :--------------: | :---------------- | :--: |
+|      period      | today または week |  ❌  |
+
+例: 今週の教室 `/v1/google/sheets/room?period=week`
+
+> [!TIP]
+>
+> `period`は省略できる。デフォルトは`period=today`になる。
 
 ##### Cron v1
 

--- a/src/api/v1/discord/service.ts
+++ b/src/api/v1/discord/service.ts
@@ -57,12 +57,26 @@ export namespace DiscordService {
        */
       const command = interaction.data.options?.[0].name
         .toString()
-        .toLowerCase();
+        .toLowerCase() as (typeof DISCORD_COMMANDS)[number]["options"][number]["name"];
 
       // コマンドの追加はここに追記
       switch (command) {
         case "today": {
-          const message = await GoogleSheetsService.getRoomInfo(env);
+          const message = await GoogleSheetsService.getRoomInfo({
+            ...env,
+            query: { period: "today" },
+          });
+          return discordInteractionHandler({
+            type: InteractionResponseType.ChannelMessageWithSource,
+            data: { content: message },
+          });
+        }
+
+        case "week": {
+          const message = await GoogleSheetsService.getRoomInfo({
+            ...env,
+            query: { period: "week" },
+          });
           return discordInteractionHandler({
             type: InteractionResponseType.ChannelMessageWithSource,
             data: { content: message },

--- a/src/api/v1/google/sheets/controller.ts
+++ b/src/api/v1/google/sheets/controller.ts
@@ -1,13 +1,22 @@
 import type { Context } from "hono";
+import { safeParse } from "valibot";
 import { parseEnv } from "~/constants";
-import { apiSuccessHandler } from "~/handler";
+import { APIError, apiSuccessHandler } from "~/handler";
 import type { Bindings } from "~/types";
+import { QueryParamsSchema } from "./schema";
 import { GoogleSheetsService } from "./service";
 
 export namespace GoogleSheetsController {
   export async function getRoom(c: Context<{ Bindings: Bindings }>) {
+    const query = safeParse(QueryParamsSchema, c.req.query());
+    if (!query.success) {
+      throw new APIError("Invalid query parameters", 400);
+    }
     const { googleSheets } = parseEnv(c.env);
-    const message = await GoogleSheetsService.getRoomInfo(googleSheets);
+    const message = await GoogleSheetsService.getRoomInfo({
+      ...googleSheets,
+      query: query.output,
+    });
     return apiSuccessHandler({ message }, c);
   }
 }

--- a/src/api/v1/google/sheets/route.ts
+++ b/src/api/v1/google/sheets/route.ts
@@ -4,6 +4,6 @@ import { GoogleSheetsController } from "./controller";
 
 const router = new Hono<{ Bindings: Bindings }>();
 
-router.get("/sheets/room/today", GoogleSheetsController.getRoom);
+router.get("/sheets/room", GoogleSheetsController.getRoom);
 
 export default router;

--- a/src/api/v1/google/sheets/schema.ts
+++ b/src/api/v1/google/sheets/schema.ts
@@ -1,0 +1,11 @@
+import { type InferOutput, object, optional, picklist } from "valibot";
+
+const period = ["today", "week"] as const;
+
+export type Period = (typeof period)[number];
+
+export const QueryParamsSchema = object({
+  period: optional(picklist(period)),
+});
+
+export type QueryParamsSchemaType = InferOutput<typeof QueryParamsSchema>;

--- a/src/api/v1/google/sheets/service.ts
+++ b/src/api/v1/google/sheets/service.ts
@@ -1,12 +1,13 @@
 import type { ParsedEnv } from "~/constants";
 import { APIError } from "~/handler";
 import { GoogleAuth } from "~/utils/google";
+import type { Query } from "./types";
 
 export namespace GoogleSheetsService {
   export async function getRoomInfo(
-    props: ParsedEnv["googleSheets"],
+    props: ParsedEnv["googleSheets"] & Query,
   ): Promise<string> {
-    const { clientEmail, privateKey, spreadsheetId, range } = props;
+    const { clientEmail, privateKey, spreadsheetId, range, query } = props;
     const today = new Date();
     const sheetName = `${today.getMonth() + 1}月分`;
 
@@ -80,6 +81,16 @@ export namespace GoogleSheetsService {
         range: string;
         values: Parameters<typeof formatRoomResponse>[0];
       } = await response.json();
+
+      // 今日の情報を返す
+      if (query.period === "today") {
+        return formatRoomResponse(data.values);
+      }
+      // 週間の情報を返す
+      if (query.period === "week") {
+        return formatRoomResponseWeek(data.values);
+      }
+      // デフォルトは今日の情報を返す
       return formatRoomResponse(data.values);
     } catch (err) {
       console.error(err);
@@ -121,6 +132,72 @@ export namespace GoogleSheetsService {
     const message = !room
       ? "今日の教室は未定だよ！"
       : `今日の教室は\`${room}\`だよ！\n\`\`\`<日付> ${date}(${dayOfWeek})\n<授業> ${className}${!note ? "" : `\n${note}`}\n\`\`\``;
+
+    return message;
+  }
+
+  function formatRoomResponseWeek(
+    values: string[][] | null | undefined,
+  ): string {
+    if (!values || values.length === 0) {
+      return "今月は何もないよ！";
+    }
+
+    const today = new Date();
+    const currentDay = today.getDay();
+    const startOfWeek = new Date(today);
+    startOfWeek.setDate(today.getDate() - currentDay); // 今週の日曜日
+    const endOfWeek = new Date(startOfWeek);
+    endOfWeek.setDate(startOfWeek.getDate() + 6); // 今週の土曜日
+
+    console.log(values);
+
+    // 今週の日付の範囲内にある行を全て取得
+    const weekRows = values.filter((row) => {
+      const date = row[1]; // B列に日付
+      if (!date) return false;
+      const dateParts = date.split("/"); // "M/D" => ["M", "D"]
+      if (dateParts.length !== 2) return false;
+      const month = Number(dateParts[0]) - 1;
+      const day = Number(dateParts[1]);
+      const rowDate = new Date(today.getFullYear(), month, day);
+      return rowDate >= startOfWeek && rowDate <= endOfWeek;
+    });
+
+    if (!weekRows || weekRows.length === 0) {
+      return "今週の情報がないよ！";
+    }
+
+    /**
+     * @example
+     * 今週の教室だよ！
+     * ```
+     * <日付> 1/1(月)
+     * <授業> 自習室
+     * 備考
+     * ---
+     * <日付> 1/2(火)
+     * <授業> 自習室
+     * 備考
+     * ```
+     */
+    let message = "今週の教室だよ！\n```";
+
+    for (const row of weekRows) {
+      const className = row[0] || "情報なし"; // A列に授業名
+      const date = row[1] || "情報なし"; // B列に日付
+      const dayOfWeek = row[2] || "情報なし"; // C列に曜日
+      const room = row[3] || "未定"; // D列に教室
+      const note = row[4] || null; // E列に備考
+
+      message += `\n<日付> ${date}(${dayOfWeek})`;
+      message += `\n<授業> ${className}`;
+      message += `\n<教室> ${room}`;
+      if (note) message += `\n<備考> ${note}`;
+      if (weekRows.indexOf(row) !== weekRows.length - 1) message += "\n---";
+    }
+
+    message += "\n```";
 
     return message;
   }

--- a/src/api/v1/google/sheets/types.ts
+++ b/src/api/v1/google/sheets/types.ts
@@ -1,0 +1,5 @@
+import type { QueryParamsSchemaType } from "./schema";
+
+export type Query = {
+  query: QueryParamsSchemaType;
+};

--- a/src/constants/discord.ts
+++ b/src/constants/discord.ts
@@ -7,6 +7,7 @@ import type { DiscordCommand } from "~/types";
 /**
  * Discord のコマンド一覧
  * * `/roomy today` 今日の教室を確認する
+ * * `/roomy week` 今週の教室を確認する
  * * `/roomy help` 使い方・コマンド一覧を表示する
  */
 export const DISCORD_COMMANDS = [

--- a/src/constants/discord.ts
+++ b/src/constants/discord.ts
@@ -21,6 +21,11 @@ export const DISCORD_COMMANDS = [
         type: ApplicationCommandOptionType.Subcommand,
       },
       {
+        name: "week",
+        description: "今週の教室",
+        type: ApplicationCommandOptionType.Subcommand,
+      },
+      {
         name: "help",
         description: "使い方・コマンド一覧",
         type: ApplicationCommandOptionType.Subcommand,


### PR DESCRIPTION
## 変更内容

- APIエンドポイント `/v1/google/sheets/room/today`を`/v1/google/sheets/room`に変更
- `/v1/google/sheets/room`で期間を指定できるように変更
- Discordコマンドおよびインタラクションに`week`を追加
- READMEを更新

## 破壊的変更

あり