### PR TITLE
ci(quality): corepack有効化方法を変更

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Enable Corepack
         run: |
+          npm i -g corepack@latest
           corepack enable
-          corepack prepare pnpm@10.0.0 --activate
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Related to #2

## 概要

#2 の暫定対応として、`corepack prepare pnpm@10.0.0 --activate`を使っていた。
しかし、これでは`packageManager`での指定に限らず、pnpmのバージョンが固定されてしまう。
`packageManager`とバージョン同期を取れるように変更した。

## 破壊的変更

なし