### PR TITLE
chore(engines): node v22からv20に緩和

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1-beta.17",
   "private": true,
   "engines": {
-    "node": ">=22",
+    "node": ">=20",
     "npm": "pnpmを使ってね🤗"
   },
   "packageManager": "pnpm@10.0.0",


### PR DESCRIPTION
## 概要

`package.json`の`engines`をnode v22からv20に緩和する。

## 内容

このレポジトリでは、Dependabotでのアップデートを有効にしている。
しかし、Dependabotでは node v20 を使用しており、このレポジトリのnodeバージョン要件に満たないためアップデートに失敗する。

https://github.com/dependabot/dependabot-core/blob/b9ea83bcad97700d007e5e5b57609df0aee756c1/npm_and_yarn/Dockerfile#L15-L33

そこで、解決策として以下2通りを考えた。

1. `.npmrc`の`engine-strict=true`を消す
2. `package.json`のnode指定をnode v20からnode v22に変更する

`1.`の方法ではパッケージマネージャの強制も緩和されてしまうので、`2.`の方法を採用した。

## 破壊的変更

なし
